### PR TITLE
Make it possible to read FileSystemResource in PoiItemReader

### DIFF
--- a/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/poi/PoiItemReader.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/poi/PoiItemReader.java
@@ -25,7 +25,6 @@ import org.springframework.core.io.Resource;
 
 import java.io.Closeable;
 import java.io.InputStream;
-import java.io.PushbackInputStream;
 
 /**
  * {@link org.springframework.batch.item.ItemReader} implementation which uses apache POI to read an Excel
@@ -78,9 +77,7 @@ public class PoiItemReader<T> extends AbstractExcelItemReader<T> {
     @Override
     protected void openExcelFile(final Resource resource) throws Exception {
         workbookStream = resource.getInputStream();
-        if (!workbookStream.markSupported() && !(workbookStream instanceof PushbackInputStream)) {
-            throw new IllegalStateException("InputStream MUST either support mark/reset, or be wrapped as a PushbackInputStream");
-        }
+
         this.workbook = WorkbookFactory.create(workbookStream);
         this.workbook.setMissingCellPolicy(Row.CREATE_NULL_AS_BLANK);
     }


### PR DESCRIPTION
This is the solution to the issue #34 

To read excel file resources using FileSystemResource, remove unnecessary validation check in PoiItemReader.openExcelFile method

```java
if (!workbookStream.markSupported() && !(workbookStream instanceof PushbackInputStream)) {
    throw new IllegalStateException("InputStream MUST either support mark/reset, or be wrapped as a PushbackInputStream");
}
```

Validation check is unnecessary because WorkbookFactory.create(workbookStream) method wrap InputStream as PushBackInputStream when that InputStream isn’t marksupported

```java
if(!((InputStream)inp).markSupported()) {
    inp = new PushbackInputStream((InputStream)inp, 8);
}
```

So after removing unnecessary validation check, I tested PoiItemReader.openExcelFile method by putting FileSystemResource as a parameter value and check it perfectly works.

@mminella , @mdeinum 
please check my pull request
