### PR TITLE
Support representing Excel rows as other types than String[]

### DIFF
--- a/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/AbstractExcelItemReader.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/AbstractExcelItemReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,23 +32,24 @@ import org.springframework.util.ClassUtils;
  * file. It will read the file sheet for sheet and row for row. It is loosy based on
  * the {@link org.springframework.batch.item.file.FlatFileItemReader}
  *
+ * @param <R> Type used for representing a single row, such as an array
  * @param <T> the type
  * @author Marten Deinum
  * @since 0.5.0
  */
-public abstract class AbstractExcelItemReader<T> extends AbstractItemCountingItemStreamItemReader<T> implements
+public abstract class AbstractExcelItemReader<R,T> extends AbstractItemCountingItemStreamItemReader<T> implements
         ResourceAwareItemReaderItemStream<T>, InitializingBean {
 
     protected final Log logger = LogFactory.getLog(getClass());
     private Resource resource;
     private int linesToSkip = 0;
     private int currentSheet = 0;
-    private RowMapper<T> rowMapper;
-    private RowCallbackHandler skippedRowsCallback;
+    private RowMapper<R,T> rowMapper;
+    private RowCallbackHandler<R> skippedRowsCallback;
     private boolean noInput = false;
     private boolean strict = true;
-    private RowSetFactory rowSetFactory = new DefaultRowSetFactory();
-    private RowSet rs;
+    private RowSetFactory<R> rowSetFactory = (RowSetFactory<R>) new DefaultRowSetFactory();
+    private RowSet<R> rs;
 
     public AbstractExcelItemReader() {
         super();
@@ -117,7 +118,7 @@ public abstract class AbstractExcelItemReader<T> extends AbstractItemCountingIte
     }
 
     private void openSheet() {
-        final Sheet sheet = this.getSheet(this.currentSheet);
+        final Sheet<R> sheet = this.getSheet(this.currentSheet);
         this.rs =rowSetFactory.create(sheet);
 
 
@@ -195,7 +196,7 @@ public abstract class AbstractExcelItemReader<T> extends AbstractItemCountingIte
      *
      * @param rowMapper the {@code RowMapper} to use.
      */
-    public void setRowMapper(final RowMapper<T> rowMapper) {
+    public void setRowMapper(final RowMapper<R,T> rowMapper) {
         this.rowMapper = rowMapper;
     }
 
@@ -205,14 +206,14 @@ public abstract class AbstractExcelItemReader<T> extends AbstractItemCountingIte
      *
      * @param rowSetFactory the {@code RowSetFactory} to use.
      */
-    public void setRowSetFactory(RowSetFactory rowSetFactory) {
+    public void setRowSetFactory(RowSetFactory<R> rowSetFactory) {
         this.rowSetFactory = rowSetFactory;
     }
 
     /**
      * @param skippedRowsCallback will be called for each one of the initial skipped lines before any items are read.
      */
-    public void setSkippedRowsCallback(final RowCallbackHandler skippedRowsCallback) {
+    public void setSkippedRowsCallback(final RowCallbackHandler<R> skippedRowsCallback) {
         this.skippedRowsCallback = skippedRowsCallback;
     }
 }

--- a/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/ExcelFileParseException.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/ExcelFileParseException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ public class ExcelFileParseException extends ParseException {
 
     private final String filename;
     private final String sheet;
-    private final String[] row;
+    private final Object row;
     private final int rowNumber;
 
     /**
@@ -43,7 +43,7 @@ public class ExcelFileParseException extends ParseException {
      * @param row       the row data as text
      */
     public ExcelFileParseException(final String message, final Throwable cause, final String filename,
-                                   final String sheet, final int rowNumber, final String[] row) {
+                                   final String sheet, final int rowNumber, final Object row) {
         super(message, cause);
         this.filename = filename;
         this.sheet = sheet;
@@ -63,7 +63,7 @@ public class ExcelFileParseException extends ParseException {
         return this.rowNumber;
     }
 
-    public String[] getRow() {
+    public Object getRow() {
         return this.row;
     }
 

--- a/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/RowCallbackHandler.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/RowCallbackHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,13 @@ import org.springframework.batch.item.excel.support.rowset.RowSet;
 
 /**
  * Callback to handle skipped lines. Useful for header/footer processing.
- *
+ * 
+ * @param <R> Type used for representing a single row, such as an array
  * @author Marten Deinum
  * @since 0.5.0
  */
-public interface RowCallbackHandler {
+public interface RowCallbackHandler<R> {
 
-    void handleRow(RowSet rs);
+    void handleRow(RowSet<R> rs);
 
 }

--- a/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/RowMapper.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/RowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,12 @@ import org.springframework.batch.item.excel.support.rowset.RowSet;
 /**
  * Map rows from an excel sheet to an object.
  *
- * @param <T> the type
+ * @param <R> Type used for representing a single row, such as an array
+ * @param <T> the type to map to
  * @author Marten Deinum
  * @since 0.5.0
  */
-public interface RowMapper<T> {
+public interface RowMapper<R,T> {
 
     /**
      * Implementations must implement this method to map the provided row to
@@ -35,6 +36,6 @@ public interface RowMapper<T> {
      * @return mapped object of type T
      * @throws Exception if error occured while parsing.
      */
-    T mapRow(RowSet rs) throws Exception;
+    T mapRow(RowSet<R> rs) throws Exception;
 
 }

--- a/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/Sheet.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/Sheet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,11 @@ package org.springframework.batch.item.excel;
 /**
  * Interface to wrap different Excel implementations like JExcel, JXL or Apache POI.
  *
+ * @param <R> Type used for representing a single row, such as an array
  * @author Marten Deinum
  * @since 0.5.0
  */
-public interface Sheet {
+public interface Sheet<R> {
 
     /**
      * Get the number of rows in this sheet.
@@ -39,12 +40,12 @@ public interface Sheet {
     String getName();
 
     /**
-     * Get the row as a String[]. Returns null if the row doesn't exist.
+     * Get the row as a {@link R}. Returns null if the row doesn't exist.
      *
      * @param rowNumber the row number to read.
-     * @return a String[] or null
+     * @return a {@link R} or null
      */
-    String[] getRow(int rowNumber);
+    R getRow(int rowNumber);
 
     /**
      * The number of columns in this sheet.

--- a/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/jxl/JxlItemReader.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/jxl/JxlItemReader.java
@@ -29,6 +29,7 @@ import org.springframework.util.ClassUtils;
  * file. It will read the file sheet for sheet and row for row. It is based on
  * the {@link org.springframework.batch.item.file.FlatFileItemReader}
  *
+ * @param <R> Type used for representing a single row, such as an array
  * @param <T> the type
  * @author Marten Deinum
  * @since 0.5.0
@@ -36,7 +37,7 @@ import org.springframework.util.ClassUtils;
  * @deprecated since JExcelAPI is an abandoned project (no release since 2009, with serious bugs remaining)
  */
 @Deprecated
-public class JxlItemReader<T> extends AbstractExcelItemReader<T> {
+public class JxlItemReader<R,T> extends AbstractExcelItemReader<R,T> {
 
     private Workbook workbook;
 

--- a/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/jxl/JxlSheet.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/jxl/JxlSheet.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import org.springframework.batch.item.excel.Sheet;
  * @deprecated since JExcelAPI is an abandoned project (no release since 2009, with serious bugs remaining)
  */
 @Deprecated
-public class JxlSheet implements Sheet {
+public class JxlSheet implements Sheet<String[]> {
 
     private final jxl.Sheet delegate;
     private final int numberOfRows;
@@ -40,7 +40,7 @@ public class JxlSheet implements Sheet {
      *
      * @param delegate the JXL sheet
      */
-    JxlSheet(final jxl.Sheet delegate) {
+    public JxlSheet(final jxl.Sheet delegate) {
         super();
         this.delegate = delegate;
         this.numberOfRows = this.delegate.getRows();

--- a/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/mapping/BeanWrapperRowMapper.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/mapping/BeanWrapperRowMapper.java
@@ -1,5 +1,9 @@
 package org.springframework.batch.item.excel.mapping;
 
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
 import org.springframework.batch.item.excel.RowMapper;
 import org.springframework.batch.item.excel.support.rowset.RowSet;
 import org.springframework.batch.support.DefaultPropertyEditorRegistrar;
@@ -11,10 +15,6 @@ import org.springframework.util.Assert;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.validation.BindException;
 import org.springframework.validation.DataBinder;
-
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 /**
  * {@link RowMapper} implementation based on bean property paths. The
@@ -60,10 +60,11 @@ import java.util.concurrent.ConcurrentMap;
  * match is found. If more than one match is found there will be an error.
  *
  *
+ * @param <R> Type used for representing a single row, such as an array
  * @author Marten Deinum
  * @since 0.5.0
  */
-public class BeanWrapperRowMapper<T> extends DefaultPropertyEditorRegistrar implements RowMapper<T>, BeanFactoryAware, InitializingBean {
+public class BeanWrapperRowMapper<R,T> extends DefaultPropertyEditorRegistrar implements RowMapper<R,T>, BeanFactoryAware, InitializingBean {
 
     private String name;
 
@@ -155,7 +156,7 @@ public class BeanWrapperRowMapper<T> extends DefaultPropertyEditorRegistrar impl
      * @see org.springframework.batch.item.file.mapping.FieldSetMapper#mapFieldSet(org.springframework.batch.item.file.transform.FieldSet)
      */
     @Override
-    public T mapRow(RowSet rs) throws BindException {
+    public T mapRow(RowSet<R> rs) throws BindException {
         T copy = getBean();
         DataBinder binder = createBinder(copy);
         binder.bind(new MutablePropertyValues(getBeanProperties(copy, rs.getProperties())));

--- a/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/mapping/PassThroughRowMapper.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/mapping/PassThroughRowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,16 +19,17 @@ import org.springframework.batch.item.excel.RowMapper;
 import org.springframework.batch.item.excel.support.rowset.RowSet;
 
 /**
- * Pass through {@link RowMapper} useful for passing the orginal String[]
+ * Pass through {@link RowMapper} useful for passing the original row
  * back directly rather than a mapped object.
  *
+ * @param <R> Type used for representing a single row, such as an array
  * @author Marten Deinum
  * @since 0.5.0
  */
-public class PassThroughRowMapper implements RowMapper<String[]> {
+public class PassThroughRowMapper<R> implements RowMapper<R, R> {
 
     @Override
-    public String[] mapRow(final RowSet rs) throws Exception {
+    public R mapRow(final RowSet<R> rs) throws Exception {
         return rs.getCurrentRow();
     }
 

--- a/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/mapping/StringArrayPassThroughRowMapper.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/mapping/StringArrayPassThroughRowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,24 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.batch.item.excel.support.rowset;
+package org.springframework.batch.item.excel.mapping;
 
-import org.springframework.batch.item.excel.Sheet;
+import org.springframework.batch.item.excel.RowMapper;
 
 /**
- * Contract for factories which will construct a {@code RowSet} implementation.
+ * Pass through {@link RowMapper} useful for passing the original String[]
+ * back directly rather than a mapped object.
  *
- * @param <R> Type used for representing a single row, such as an array
- * @author Marten Deinum
+ * @author Mattias Jiderhamn
  * @since 0.5.0
  */
-public interface RowSetFactory<R> {
+public class StringArrayPassThroughRowMapper extends PassThroughRowMapper<String[]> {
 
-    /**
-     * Create a rowset instance.
-     *
-     * @param sheet an Excel sheet.
-     * @return a RowSet instance.
-     */
-    RowSet<R> create(Sheet<R> sheet);
 }

--- a/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/poi/ArrayPoiSheet.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/poi/ArrayPoiSheet.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2006-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.batch.item.excel.poi;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.DateUtil;
+import org.apache.poi.ss.usermodel.Row;
+
+/**
+ * Sheet implementation for Apache POI representing each row as a Object[].
+ * The type of each value in the array depends on the {@link Cell#getCellType()} of the corresponding cell. 
+ * <table>
+ *   <tr><th>Cell type</th><th>Java type</th>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link Cell#CELL_TYPE_BOOLEAN}</td>
+ *     <td>{@link java.lang.Boolean}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link Cell#CELL_TYPE_STRING}</td>
+ *     <td>{@link java.lang.String}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link Cell#CELL_TYPE_BLANK}</td>
+ *     <td>{@link java.lang.String}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link Cell#CELL_TYPE_NUMERIC} + {@link DateUtil#isCellDateFormatted(Cell)} = false</td>
+ *     <td>{@link java.lang.Double}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link Cell#CELL_TYPE_NUMERIC} + {@link DateUtil#isCellDateFormatted(Cell)} = true</td>
+ *     <td>{@link java.util.Date}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link Cell#CELL_TYPE_FORMULA}</td>
+ *     <td>{@link java.lang.String} (evaluated)</td>
+ *   </tr>
+ * </table>
+ *
+ * @author Mattias Jiderhamn
+ * @since 0.5.0
+ */
+public class ArrayPoiSheet extends PoiSheet<Object[]> {
+
+    /**
+     * Constructor which takes the delegate sheet.
+     *
+     * @param delegate the apache POI sheet
+     */
+    public ArrayPoiSheet(final org.apache.poi.ss.usermodel.Sheet delegate) {
+        super(delegate);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object[] getRow(final int rowNumber) {
+        final Row row = this.delegate.getRow(rowNumber);
+        if (row == null) {
+            return null;
+        }
+        final List<Object> cells = new LinkedList<Object>();
+
+        for (int i = 0; i < getNumberOfColumns(); i++) {
+            Cell cell = row.getCell(i);
+            switch (cell.getCellType()) {
+                case Cell.CELL_TYPE_NUMERIC:
+                    if (DateUtil.isCellDateFormatted(cell)) {
+                        cells.add(cell.getDateCellValue());
+                    } else {
+                        cells.add(cell.getNumericCellValue());
+                    }
+                    break;
+                case Cell.CELL_TYPE_BOOLEAN:
+                    cells.add(cell.getBooleanCellValue());
+                    break;
+                case Cell.CELL_TYPE_STRING:
+                case Cell.CELL_TYPE_BLANK:
+                    cells.add(cell.getStringCellValue());
+                    break;
+                case Cell.CELL_TYPE_FORMULA:
+                    cells.add(getFormulaEvaluator().evaluate(cell).formatAsString());
+                    break;
+                default:
+                    throw new IllegalArgumentException("Cannot handle cells of type " + cell.getCellType());
+            }
+        }
+        return cells.toArray(new Object[cells.size()]);
+    }
+}

--- a/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/poi/ArrayPoiSheetFactory.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/poi/ArrayPoiSheetFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2006-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.batch.item.excel.poi;
+
+/**
+ * Implementation of {@link PoiSheetFactory} that will use {@link ArrayPoiSheet} to represent each row with as a 
+ * {@code Object[]}.
+ *
+ * @author Mattias Jiderhamn
+ * @since 0.5.0
+ */
+public class ArrayPoiSheetFactory implements PoiSheetFactory<Object[]> {
+    
+    /** Create new {@link PoiSheet} instance */
+    @Override
+    public PoiSheet<Object[]> newPoiSheet(org.apache.poi.ss.usermodel.Sheet delegate) {
+        return new ArrayPoiSheet(delegate);
+    }
+
+}

--- a/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/poi/PoiSheet.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/poi/PoiSheet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,25 +16,19 @@
 
 package org.springframework.batch.item.excel.poi;
 
-import org.apache.poi.ss.usermodel.Cell;
-import org.apache.poi.ss.usermodel.DateUtil;
 import org.apache.poi.ss.usermodel.FormulaEvaluator;
-import org.apache.poi.ss.usermodel.Row;
 import org.springframework.batch.item.excel.Sheet;
-
-import java.util.Date;
-import java.util.LinkedList;
-import java.util.List;
 
 /**
  * Sheet implementation for Apache POI.
  *
+ * @param <R> Type used for representing a single row, such as an array
  * @author Marten Deinum
  * @since 0.5.0
  */
-public class PoiSheet implements Sheet {
+public abstract class PoiSheet<R> implements Sheet<R> {
 
-    private final org.apache.poi.ss.usermodel.Sheet delegate;
+    protected final org.apache.poi.ss.usermodel.Sheet delegate;
     private final int numberOfRows;
     private final String name;
 
@@ -46,7 +40,7 @@ public class PoiSheet implements Sheet {
      *
      * @param delegate the apache POI sheet
      */
-    PoiSheet(final org.apache.poi.ss.usermodel.Sheet delegate) {
+    public PoiSheet(final org.apache.poi.ss.usermodel.Sheet delegate) {
         super();
         this.delegate = delegate;
         this.numberOfRows = this.delegate.getLastRowNum() + 1;
@@ -68,47 +62,8 @@ public class PoiSheet implements Sheet {
     public String getName() {
         return this.name;
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String[] getRow(final int rowNumber) {
-        final Row row = this.delegate.getRow(rowNumber);
-        if (row == null) {
-            return null;
-        }
-        final List<String> cells = new LinkedList<String>();
-
-        for (int i = 0; i < getNumberOfColumns(); i++) {
-            Cell cell = row.getCell(i);
-            switch (cell.getCellType()) {
-                case Cell.CELL_TYPE_NUMERIC:
-                    if (DateUtil.isCellDateFormatted(cell)) {
-                        Date date = cell.getDateCellValue();
-                        cells.add(String.valueOf(date.getTime()));
-                    } else {
-                        cells.add(String.valueOf(cell.getNumericCellValue()));
-                    }
-                    break;
-                case Cell.CELL_TYPE_BOOLEAN:
-                    cells.add(String.valueOf(cell.getBooleanCellValue()));
-                    break;
-                case Cell.CELL_TYPE_STRING:
-                case Cell.CELL_TYPE_BLANK:
-                    cells.add(cell.getStringCellValue());
-                    break;
-                case Cell.CELL_TYPE_FORMULA:
-                    cells.add(getFormulaEvaluator().evaluate(cell).formatAsString());
-                    break;
-                default:
-                    throw new IllegalArgumentException("Cannot handle cells of type " + cell.getCellType());
-            }
-        }
-        return cells.toArray(new String[cells.size()]);
-    }
-
-    private FormulaEvaluator getFormulaEvaluator() {
+    
+    protected FormulaEvaluator getFormulaEvaluator() {
         if (this.evaluator == null) {
             this.evaluator = delegate.getWorkbook().getCreationHelper().createFormulaEvaluator();
         }

--- a/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/poi/PoiSheetFactory.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/poi/PoiSheetFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,24 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.batch.item.excel.support.rowset;
 
-import org.springframework.batch.item.excel.Sheet;
+package org.springframework.batch.item.excel.poi;
 
 /**
- * Contract for factories which will construct a {@code RowSet} implementation.
+ * Interface for factory that will instantiate {@link PoiSheet}s from Apache POI {@link org.apache.poi.ss.usermodel.Sheet} 
  *
  * @param <R> Type used for representing a single row, such as an array
- * @author Marten Deinum
+ * @author Mattias Jiderhamn
  * @since 0.5.0
  */
-public interface RowSetFactory<R> {
+public interface PoiSheetFactory<R> {
+    
+    /** Create new {@link PoiSheet} instance */
+    PoiSheet<R> newPoiSheet(org.apache.poi.ss.usermodel.Sheet delegate);
 
-    /**
-     * Create a rowset instance.
-     *
-     * @param sheet an Excel sheet.
-     * @return a RowSet instance.
-     */
-    RowSet<R> create(Sheet<R> sheet);
 }

--- a/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/poi/StringArrayPoiSheet.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/poi/StringArrayPoiSheet.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2006-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.batch.item.excel.poi;
+
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.DateUtil;
+import org.apache.poi.ss.usermodel.Row;
+
+/**
+ * Sheet implementation for Apache POI representing each row as a String[].
+ *
+ * @author Marten Deinum
+ * @author Mattias Jiderhamn
+ * @since 0.5.0
+ */
+public class StringArrayPoiSheet extends PoiSheet<String[]> {
+
+    /**
+     * Constructor which takes the delegate sheet.
+     *
+     * @param delegate the apache POI sheet
+     */
+    public StringArrayPoiSheet(final org.apache.poi.ss.usermodel.Sheet delegate) {
+        super(delegate);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String[] getRow(final int rowNumber) {
+        final Row row = this.delegate.getRow(rowNumber);
+        if (row == null) {
+            return null;
+        }
+        final List<String> cells = new LinkedList<String>();
+
+        for (int i = 0; i < getNumberOfColumns(); i++) {
+            Cell cell = row.getCell(i);
+            switch (cell.getCellType()) {
+                case Cell.CELL_TYPE_NUMERIC:
+                    if (DateUtil.isCellDateFormatted(cell)) {
+                        Date date = cell.getDateCellValue();
+                        cells.add(String.valueOf(date.getTime()));
+                    } else {
+                        cells.add(String.valueOf(cell.getNumericCellValue()));
+                    }
+                    break;
+                case Cell.CELL_TYPE_BOOLEAN:
+                    cells.add(String.valueOf(cell.getBooleanCellValue()));
+                    break;
+                case Cell.CELL_TYPE_STRING:
+                case Cell.CELL_TYPE_BLANK:
+                    cells.add(cell.getStringCellValue());
+                    break;
+                case Cell.CELL_TYPE_FORMULA:
+                    cells.add(getFormulaEvaluator().evaluate(cell).formatAsString());
+                    break;
+                default:
+                    throw new IllegalArgumentException("Cannot handle cells of type " + cell.getCellType());
+            }
+        }
+        return cells.toArray(new String[cells.size()]);
+    }
+}

--- a/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/poi/StringArrayPoiSheetFactory.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/poi/StringArrayPoiSheetFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,24 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.batch.item.excel.support.rowset;
 
-import org.springframework.batch.item.excel.Sheet;
+package org.springframework.batch.item.excel.poi;
 
 /**
- * Contract for factories which will construct a {@code RowSet} implementation.
+ * Implementation of {@link PoiSheetFactory} that will use {@link StringArrayPoiSheet} to represent each row with as a 
+ * {@code String[]}.
  *
- * @param <R> Type used for representing a single row, such as an array
- * @author Marten Deinum
+ * @author Mattias Jiderhamn
  * @since 0.5.0
  */
-public interface RowSetFactory<R> {
+public class StringArrayPoiSheetFactory implements PoiSheetFactory<String[]> {
+    
+    /** Create new {@link PoiSheet} instance */
+    @Override
+    public PoiSheet<String[]> newPoiSheet(org.apache.poi.ss.usermodel.Sheet delegate) {
+        return new StringArrayPoiSheet(delegate);
+    }
 
-    /**
-     * Create a rowset instance.
-     *
-     * @param sheet an Excel sheet.
-     * @return a RowSet instance.
-     */
-    RowSet<R> create(Sheet<R> sheet);
 }

--- a/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/support/rowset/AbstractRowSet.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/support/rowset/AbstractRowSet.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2006-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.item.excel.support.rowset;
+
+import org.springframework.batch.item.excel.Sheet;
+
+/**
+ * Abstract implementation of the {@code RowSet} interface, providing the ability to traverse rows.
+ *
+ * @param <R> Type used for representing a single row, such as an array
+ * @author Marten Deinum
+ * @author Mattias Jiderhamn
+ * @since 0.5.0
+ *
+ * @see DefaultRowSetFactory
+ */
+public abstract class AbstractRowSet<R> implements RowSet<R> {
+
+    private final Sheet<R> sheet;
+    private final RowSetMetaData metaData;
+
+    private int currentRowIndex = -1;
+    private R currentRow;
+
+    public AbstractRowSet(Sheet<R> sheet, RowSetMetaData metaData) {
+        this.sheet = sheet;
+        this.metaData = metaData;
+    }
+
+    @Override
+    public RowSetMetaData getMetaData() {
+        return metaData;
+    }
+
+    @Override
+    public boolean next() {
+        currentRow = null;
+        currentRowIndex++;
+        if (currentRowIndex < sheet.getNumberOfRows()) {
+            currentRow = sheet.getRow(currentRowIndex);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public int getCurrentRowIndex() {
+        return this.currentRowIndex;
+    }
+
+    @Override
+    public R getCurrentRow() {
+        return this.currentRow;
+    }
+
+}

--- a/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/support/rowset/ColumnNameExtractor.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/support/rowset/ColumnNameExtractor.java
@@ -31,6 +31,6 @@ public interface ColumnNameExtractor {
      * @param sheet the sheet
      * @return the column names
      */
-    String[] getColumnNames(Sheet sheet);
+    String[] getColumnNames(Sheet<String[]> sheet);
 
 }

--- a/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/support/rowset/DefaultRowSet.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/support/rowset/DefaultRowSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 package org.springframework.batch.item.excel.support.rowset;
 
-import org.springframework.batch.item.excel.Sheet;
-
 import java.util.Properties;
+
+import org.springframework.batch.item.excel.Sheet;
 
 /**
  * Default implementation of the {@code RowSet} interface.
@@ -27,58 +27,26 @@ import java.util.Properties;
  *
  * @see org.springframework.batch.item.excel.support.rowset.DefaultRowSetFactory
  */
-public class DefaultRowSet implements RowSet {
+public class DefaultRowSet extends AbstractRowSet<String[]> {
 
-    private final Sheet sheet;
-    private final RowSetMetaData metaData;
-
-    private int currentRowIndex = -1;
-    private String[] currentRow;
-
-    DefaultRowSet(Sheet sheet, RowSetMetaData metaData) {
-        this.sheet = sheet;
-        this.metaData = metaData;
-    }
-
-    @Override
-    public RowSetMetaData getMetaData() {
-        return metaData;
-    }
-
-    @Override
-    public boolean next() {
-        currentRow = null;
-        currentRowIndex++;
-        if (currentRowIndex < sheet.getNumberOfRows()) {
-            currentRow = sheet.getRow(currentRowIndex);
-            return true;
-        }
-        return false;
-    }
-
-    @Override
-    public int getCurrentRowIndex() {
-        return this.currentRowIndex;
-    }
-
-    @Override
-    public String[] getCurrentRow() {
-        return this.currentRow;
+    DefaultRowSet(Sheet<String[]> sheet, RowSetMetaData metaData) {
+        super(sheet, metaData);
     }
 
     @Override
     public String getColumnValue(int idx) {
-        return currentRow[idx];
+        return getCurrentRow()[idx];
     }
 
     @Override
     public Properties getProperties() {
-        final String[] names = metaData.getColumnNames();
+        final String[] names = getMetaData().getColumnNames();
         if (names == null) {
             throw new IllegalStateException("Cannot create properties without meta data");
         }
 
         Properties props = new Properties();
+        final String[] currentRow = getCurrentRow();
         for (int i = 0; i < currentRow.length; i++) {
             String value = currentRow[i];
             if (value != null) {

--- a/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/support/rowset/DefaultRowSetFactory.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/support/rowset/DefaultRowSetFactory.java
@@ -25,12 +25,12 @@ import org.springframework.batch.item.excel.Sheet;
  * @author Marten Deinum
  * @since 0.5.0
  */
-public class DefaultRowSetFactory implements RowSetFactory {
+public class DefaultRowSetFactory implements RowSetFactory<String[]> {
 
     private ColumnNameExtractor columnNameExtractor = new RowNumberColumnNameExtractor();
 
     @Override
-    public RowSet create(Sheet sheet) {
+    public RowSet<String[]> create(Sheet<String[]> sheet) {
         DefaultRowSetMetaData metaData = new DefaultRowSetMetaData(sheet);
         metaData.setColumnNameExtractor(columnNameExtractor);
         return new DefaultRowSet(sheet, metaData);

--- a/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/support/rowset/DefaultRowSetMetaData.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/support/rowset/DefaultRowSetMetaData.java
@@ -28,11 +28,11 @@ import org.springframework.batch.item.excel.Sheet;
  */
 public class DefaultRowSetMetaData implements RowSetMetaData {
 
-    private final Sheet sheet;
+    private final Sheet<String[]> sheet;
 
     private ColumnNameExtractor columnNameExtractor;
 
-    DefaultRowSetMetaData(Sheet sheet) {
+    public DefaultRowSetMetaData(Sheet<String[]> sheet) {
         this.sheet = sheet;
     }
 

--- a/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/support/rowset/RowNumberColumnNameExtractor.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/support/rowset/RowNumberColumnNameExtractor.java
@@ -29,7 +29,7 @@ public class RowNumberColumnNameExtractor implements ColumnNameExtractor {
     private int headerRowNumber;
 
     @Override
-    public String[] getColumnNames(final Sheet sheet) {
+    public String[] getColumnNames(final Sheet<String[]> sheet) {
         return sheet.getRow(headerRowNumber);
     }
 

--- a/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/support/rowset/RowSet.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/support/rowset/RowSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,12 @@ import java.util.Properties;
 /**
  * Used by the {@code org.springframework.batch.item.excel.AbstractExcelItemReader} to abstract away
  * the complexities of the underlying Excel API implementations.
- *
+ * 
+ * @param <R> Type used for representing a single row, such as an array
  * @author Marten Deinum
  * @since 0.5.0
  */
-public interface RowSet {
+public interface RowSet<R> {
 
     /**
      * Retrieves the meta data (name of the sheet, number of columns, names) of this row set.
@@ -49,11 +50,11 @@ public interface RowSet {
     int getCurrentRowIndex();
 
     /**
-     * Return the current row as a String[].
+     * Return the current row represented as {@link R}.
      *
-     * @return the row as a String[]
+     * @return the row represented as {@link R}
      */
-    String[] getCurrentRow();
+    R getCurrentRow();
 
     /**
      * Retrieves the value of the indicated column in the current row as a String object.

--- a/spring-batch-excel/src/test/java/org/springframework/batch/item/excel/AbstractExcelItemReaderTests.java
+++ b/spring-batch-excel/src/test/java/org/springframework/batch/item/excel/AbstractExcelItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.batch.item.ExecutionContext;
-import org.springframework.batch.item.excel.mapping.PassThroughRowMapper;
+import org.springframework.batch.item.excel.mapping.StringArrayPassThroughRowMapper;
 import org.springframework.batch.item.excel.support.rowset.RowSet;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -47,10 +47,10 @@ public abstract class AbstractExcelItemReaderTests  {
         this.itemReader = createExcelItemReader();
         this.itemReader.setLinesToSkip(1); //First line is column names
         this.itemReader.setResource(new ClassPathResource("org/springframework/batch/item/excel/player.xls"));
-        this.itemReader.setRowMapper(new PassThroughRowMapper());
-        this.itemReader.setSkippedRowsCallback(new RowCallbackHandler() {
+        this.itemReader.setRowMapper(new StringArrayPassThroughRowMapper());
+        this.itemReader.setSkippedRowsCallback(new RowCallbackHandler<String[]>() {
 
-            public void handleRow(RowSet rs) {
+            public void handleRow(RowSet<String[]> rs) {
                 logger.info("Skipping: " + StringUtils.arrayToCommaDelimitedString(rs.getCurrentRow()));
             }
         });

--- a/spring-batch-excel/src/test/java/org/springframework/batch/item/excel/BeanPropertyItemReaderTest.java
+++ b/spring-batch-excel/src/test/java/org/springframework/batch/item/excel/BeanPropertyItemReaderTest.java
@@ -1,13 +1,13 @@
 package org.springframework.batch.item.excel;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.Player;
 import org.springframework.batch.item.excel.mapping.BeanWrapperRowMapper;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -32,7 +32,7 @@ public class BeanPropertyItemReaderTest {
 
         reader = new MockExcelItemReader<Player>(sheet);
 
-        BeanWrapperRowMapper<Player> rowMapper = new BeanWrapperRowMapper<Player>();
+        BeanWrapperRowMapper<String[], Player> rowMapper = new BeanWrapperRowMapper<String[], Player>();
         rowMapper.setTargetType(Player.class);
         rowMapper.afterPropertiesSet();
 

--- a/spring-batch-excel/src/test/java/org/springframework/batch/item/excel/BeanPropertyWithStaticHeaderItemReaderTest.java
+++ b/spring-batch-excel/src/test/java/org/springframework/batch/item/excel/BeanPropertyWithStaticHeaderItemReaderTest.java
@@ -1,5 +1,8 @@
 package org.springframework.batch.item.excel;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.batch.item.ExecutionContext;
@@ -7,9 +10,6 @@ import org.springframework.batch.item.Player;
 import org.springframework.batch.item.excel.mapping.BeanWrapperRowMapper;
 import org.springframework.batch.item.excel.support.rowset.DefaultRowSetFactory;
 import org.springframework.batch.item.excel.support.rowset.StaticColumnNameExtractor;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -33,7 +33,7 @@ public class BeanPropertyWithStaticHeaderItemReaderTest {
 
         reader = new MockExcelItemReader<Player>(sheet);
 
-        BeanWrapperRowMapper<Player> rowMapper = new BeanWrapperRowMapper<Player>();
+        BeanWrapperRowMapper<String[], Player> rowMapper = new BeanWrapperRowMapper<String[], Player>();
         rowMapper.setTargetType(Player.class);
         rowMapper.afterPropertiesSet();
 

--- a/spring-batch-excel/src/test/java/org/springframework/batch/item/excel/MockExcelItemReader.java
+++ b/spring-batch-excel/src/test/java/org/springframework/batch/item/excel/MockExcelItemReader.java
@@ -1,15 +1,15 @@
 package org.springframework.batch.item.excel;
 
-import org.springframework.core.io.ByteArrayResource;
-import org.springframework.core.io.Resource;
-
 import java.util.Collections;
 import java.util.List;
+
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
 
 /**
  * Created by in329dei on 17-9-2014.
  */
-public class MockExcelItemReader<T> extends AbstractExcelItemReader<T> {
+public class MockExcelItemReader<T> extends AbstractExcelItemReader<String[],T> {
 
 
     private final List<MockSheet> sheets;
@@ -24,7 +24,7 @@ public class MockExcelItemReader<T> extends AbstractExcelItemReader<T> {
     }
 
     @Override
-    protected Sheet getSheet(int sheet) {
+    protected Sheet<String[]> getSheet(int sheet) {
         return sheets.get(sheet);
     }
 

--- a/spring-batch-excel/src/test/java/org/springframework/batch/item/excel/MockSheet.java
+++ b/spring-batch-excel/src/test/java/org/springframework/batch/item/excel/MockSheet.java
@@ -1,8 +1,5 @@
 package org.springframework.batch.item.excel;
 
-import jxl.Cell;
-import org.springframework.batch.item.excel.jxl.JxlUtils;
-
 import java.util.List;
 
 /**
@@ -11,7 +8,7 @@ import java.util.List;
  * @author Marten Deinum
  * @since 0.5.0
  */
-public class MockSheet implements Sheet {
+public class MockSheet implements Sheet<String[]> {
 
     private final List<String[]> rows;
     private final String name;

--- a/spring-batch-excel/src/test/java/org/springframework/batch/item/excel/mapping/BeanWrapperRowMapperTest.java
+++ b/spring-batch-excel/src/test/java/org/springframework/batch/item/excel/mapping/BeanWrapperRowMapperTest.java
@@ -1,5 +1,8 @@
 package org.springframework.batch.item.excel.mapping;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Test;
 import org.springframework.batch.item.Player;
 import org.springframework.batch.item.excel.MockSheet;
@@ -10,9 +13,6 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -30,7 +30,7 @@ public class BeanWrapperRowMapperTest {
 
     @Test
     public void givenAValidRowWhenMappingThenAValidPlayerShouldBeConstructed() throws Exception {
-        BeanWrapperRowMapper<Player> mapper = new BeanWrapperRowMapper<Player>();
+        BeanWrapperRowMapper<String[], Player> mapper = new BeanWrapperRowMapper<String[], Player>();
         mapper.setTargetType(Player.class);
         mapper.afterPropertiesSet();
 
@@ -40,7 +40,7 @@ public class BeanWrapperRowMapperTest {
         MockSheet sheet = new MockSheet("players", rows);
 
 
-        RowSet rs = new DefaultRowSetFactory().create(sheet);
+        RowSet<String[]> rs = new DefaultRowSetFactory().create(sheet);
         rs.next();
         rs.next();
 
@@ -60,7 +60,7 @@ public class BeanWrapperRowMapperTest {
     public void givenAValidRowWhenMappingThenAValidPlayerShouldBeConstructedBasedOnPrototype() throws Exception {
 
         ApplicationContext ctx = new AnnotationConfigApplicationContext(TestConfig.class);
-        BeanWrapperRowMapper<Player> mapper = new BeanWrapperRowMapper<Player>();
+        BeanWrapperRowMapper<String[], Player> mapper = new BeanWrapperRowMapper<String[], Player>();
         mapper.setPrototypeBeanName("player");
         mapper.setBeanFactory(ctx);
         mapper.afterPropertiesSet();
@@ -70,7 +70,7 @@ public class BeanWrapperRowMapperTest {
         rows.add( new String[]{"AbduKa00", "Abdul-Jabbar", "Karim", "rb", "1974", "1996"});
         MockSheet sheet = new MockSheet("players", rows);
 
-        RowSet rs = new DefaultRowSetFactory().create(sheet);
+        RowSet<String[]> rs = new DefaultRowSetFactory().create(sheet);
         rs.next();
         rs.next();
         Player p = mapper.mapRow(rs);

--- a/spring-batch-excel/src/test/java/org/springframework/batch/item/excel/mapping/StringArrayPassThroughRowMapperTest.java
+++ b/spring-batch-excel/src/test/java/org/springframework/batch/item/excel/mapping/StringArrayPassThroughRowMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
  */
 package org.springframework.batch.item.excel.mapping;
 
+import java.util.Collections;
+
 import org.junit.Test;
 import org.springframework.batch.item.excel.MockSheet;
 import org.springframework.batch.item.excel.support.rowset.DefaultRowSetFactory;
 import org.springframework.batch.item.excel.support.rowset.RowSet;
-
-import java.util.Collections;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertTrue;
@@ -30,16 +30,16 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Marten Deinum
  */
-public class PassThroughRowMapperTest {
+public class StringArrayPassThroughRowMapperTest {
 
-    private final PassThroughRowMapper rowMapper = new PassThroughRowMapper();
+    private final StringArrayPassThroughRowMapper rowMapper = new StringArrayPassThroughRowMapper();
 
     @Test
     public void mapRowShouldReturnSameValues() throws Exception {
 
         final String[] row = new String[]{"foo", "bar", "baz"};
         MockSheet sheet = new MockSheet("mock", Collections.singletonList( row));
-        RowSet rs = new DefaultRowSetFactory().create(sheet);
+        RowSet<String[]> rs = new DefaultRowSetFactory().create(sheet);
         assertTrue(rs.next());
         assertArrayEquals(row, this.rowMapper.mapRow(rs));
     }

--- a/spring-batch-excel/src/test/java/org/springframework/batch/item/excel/poi/PoiItemReaderXlsTest.java
+++ b/spring-batch-excel/src/test/java/org/springframework/batch/item/excel/poi/PoiItemReaderXlsTest.java
@@ -15,8 +15,6 @@
  */
 package org.springframework.batch.item.excel.poi;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.springframework.batch.item.excel.AbstractExcelItemReader;
 import org.springframework.batch.item.excel.AbstractExcelItemReaderTests;
 
@@ -24,7 +22,7 @@ public class PoiItemReaderXlsTest extends AbstractExcelItemReaderTests {
 
     @Override
     protected AbstractExcelItemReader createExcelItemReader() {
-        return new PoiItemReader();
+        return PoiItemReader.newStringArrayItemInstance();
     }
 
 }

--- a/spring-batch-excel/src/test/java/org/springframework/batch/item/excel/poi/PoiItemReaderXlsxTest.java
+++ b/spring-batch-excel/src/test/java/org/springframework/batch/item/excel/poi/PoiItemReaderXlsxTest.java
@@ -28,6 +28,6 @@ public class PoiItemReaderXlsxTest extends AbstractExcelItemReaderTests {
 
     @Override
     protected AbstractExcelItemReader createExcelItemReader() {
-        return new PoiItemReader();
+        return PoiItemReader.newStringArrayItemInstance();
     }
 }


### PR DESCRIPTION
Adjust interfaces to be generic and supply POI implementations to represent as `String[]` or `Object[]`. Fixes #38.