### PR TITLE
Use `Collections#emptyIterator` in Neo4jItemReader

### DIFF
--- a/spring-batch-neo4j/src/main/java/org/springframework/batch/extensions/neo4j/Neo4jItemReader.java
+++ b/spring-batch-neo4j/src/main/java/org/springframework/batch/extensions/neo4j/Neo4jItemReader.java
@@ -17,6 +17,7 @@
 package org.springframework.batch.extensions.neo4j;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -218,7 +219,7 @@ public class Neo4jItemReader<T> extends AbstractPaginatedDataItemReader<T> imple
 			return queryResults.iterator();
 		}
 		else {
-			return new ArrayList<T>().iterator();
+			return Collections.emptyIterator();
 		}
 	}
 }


### PR DESCRIPTION
This PR provides small patch by using `emptyIterator` instead of allocating `new ArrayList<T>().iterator`
thanks :)