### PR TITLE
Improve resource file check

### DIFF
--- a/spring-batch-excel/src/main/java/org/springframework/batch/extensions/excel/poi/PoiItemReader.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/extensions/excel/poi/PoiItemReader.java
@@ -17,7 +17,6 @@
 package org.springframework.batch.extensions.excel.poi;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.InputStream;
 
 import org.apache.poi.ss.usermodel.Row;
@@ -80,16 +79,14 @@ public class PoiItemReader<T> extends AbstractExcelItemReader<T> {
 	 */
 	@Override
 	protected void openExcelFile(final Resource resource, String password) throws Exception {
-
-		try {
+		if (resource.isFile()) {
 			File file = resource.getFile();
 			this.workbook = WorkbookFactory.create(file, password, false);
 		}
-		catch (FileNotFoundException ex) {
+		else {
 			this.inputStream = resource.getInputStream();
 			this.workbook = WorkbookFactory.create(this.inputStream, password);
 		}
 		this.workbook.setMissingCellPolicy(Row.MissingCellPolicy.CREATE_NULL_AS_BLANK);
 	}
-
 }

--- a/spring-batch-excel/src/main/java/org/springframework/batch/extensions/excel/streaming/StreamingXlsxItemReader.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/extensions/excel/streaming/StreamingXlsxItemReader.java
@@ -17,7 +17,6 @@
 package org.springframework.batch.extensions.excel.streaming;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -63,11 +62,11 @@ public class StreamingXlsxItemReader<T> extends AbstractExcelItemReader<T> {
 
 	@Override
 	protected void openExcelFile(Resource resource, String password) throws Exception {
-		try {
+		if (resource.isFile()) {
 			File file = resource.getFile();
 			this.pkg = OPCPackage.open(file, PackageAccess.READ);
 		}
-		catch (FileNotFoundException ex) {
+		else {
 			this.inputStream = resource.getInputStream();
 			this.pkg = OPCPackage.open(this.inputStream);
 		}


### PR DESCRIPTION
With this commit we use the isFile check introduced in
Spring 5 to check if something is an actaul file resource
instead of relying on FileNotFoundException.

Resource implementations didn't consistently throw a
FileNotFoundException (like the Google Big Query one)
leading to issues with reading.

Closes: #89