### PR TITLE
Upgrade to spring-java-format 0.0.42

### DIFF
--- a/spring-batch-excel/pom.xml
+++ b/spring-batch-excel/pom.xml
@@ -167,7 +167,7 @@
 					<dependency>
 						<groupId>io.spring.javaformat</groupId>
 						<artifactId>spring-javaformat-checkstyle</artifactId>
-						<version>0.0.35</version>
+						<version>0.0.42</version>
 					</dependency>
 				</dependencies>
 				<executions>

--- a/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/BeanPropertyItemReaderTests.java
+++ b/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/BeanPropertyItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.extensions.excel.mapping.BeanWrapperRowMapper;
-import org.springframework.batch.extensions.excel.support.rowset.DefaultRowSetFactory;
-import org.springframework.batch.extensions.excel.support.rowset.StaticColumnNameExtractor;
 import org.springframework.batch.item.ExecutionContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,15 +32,16 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Marten Deinum
  * @since 0.1.0
  */
-public class BeanPropertyWithStaticHeaderItemReaderTest {
+class BeanPropertyItemReaderTests {
 
 	private MockExcelItemReader<Player> reader;
 
 	@BeforeEach
-	public void setup() throws Exception {
+	void setup() {
 		ExecutionContext executionContext = new ExecutionContext();
 
 		List<String[]> rows = new ArrayList<>();
+		rows.add(new String[] { "id", "lastName", "firstName", "position", "birthYear", "debutYear" });
 		rows.add(new String[] { "AbduKa00", "Abdul-Jabbar", "Karim", "rb", "1974", "1996" });
 		rows.add(new String[] { "AbduRa00", "Abdullah", "Rabih", "rb", "1975", "1999" });
 		MockSheet sheet = new MockSheet("players", rows);
@@ -53,18 +52,15 @@ public class BeanPropertyWithStaticHeaderItemReaderTest {
 		rowMapper.setTargetType(Player.class);
 		rowMapper.afterPropertiesSet();
 
+		this.reader.setLinesToSkip(1); // Skip first row as that is the header
 		this.reader.setRowMapper(rowMapper);
 
-		DefaultRowSetFactory factory = new DefaultRowSetFactory();
-		factory.setColumnNameExtractor(new StaticColumnNameExtractor(
-				new String[] { "id", "lastName", "firstName", "position", "birthYear", "debutYear" }));
-		this.reader.setRowSetFactory(factory);
 		this.reader.afterPropertiesSet();
 		this.reader.open(executionContext);
 	}
 
 	@Test
-	public void readandMapPlayers() throws Exception {
+	void readandMapPlayers() throws Exception {
 		Player p1 = this.reader.read();
 		Player p2 = this.reader.read();
 		Player p3 = this.reader.read();
@@ -90,7 +86,6 @@ public class BeanPropertyWithStaticHeaderItemReaderTest {
 		softly.assertThat(1999).isEqualTo(p2.getDebutYear());
 
 		softly.assertAll();
-
 	}
 
 }

--- a/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/BeanPropertyWithStaticHeaderItemReaderTests.java
+++ b/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/BeanPropertyWithStaticHeaderItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.extensions.excel.mapping.BeanWrapperRowMapper;
+import org.springframework.batch.extensions.excel.support.rowset.DefaultRowSetFactory;
+import org.springframework.batch.extensions.excel.support.rowset.StaticColumnNameExtractor;
 import org.springframework.batch.item.ExecutionContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,16 +34,15 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Marten Deinum
  * @since 0.1.0
  */
-public class BeanPropertyItemReaderTest {
+class BeanPropertyWithStaticHeaderItemReaderTests {
 
 	private MockExcelItemReader<Player> reader;
 
 	@BeforeEach
-	public void setup() throws Exception {
+	void setup() {
 		ExecutionContext executionContext = new ExecutionContext();
 
 		List<String[]> rows = new ArrayList<>();
-		rows.add(new String[] { "id", "lastName", "firstName", "position", "birthYear", "debutYear" });
 		rows.add(new String[] { "AbduKa00", "Abdul-Jabbar", "Karim", "rb", "1974", "1996" });
 		rows.add(new String[] { "AbduRa00", "Abdullah", "Rabih", "rb", "1975", "1999" });
 		MockSheet sheet = new MockSheet("players", rows);
@@ -52,15 +53,18 @@ public class BeanPropertyItemReaderTest {
 		rowMapper.setTargetType(Player.class);
 		rowMapper.afterPropertiesSet();
 
-		this.reader.setLinesToSkip(1); // Skip first row as that is the header
 		this.reader.setRowMapper(rowMapper);
 
+		DefaultRowSetFactory factory = new DefaultRowSetFactory();
+		factory.setColumnNameExtractor(new StaticColumnNameExtractor(
+				new String[] { "id", "lastName", "firstName", "position", "birthYear", "debutYear" }));
+		this.reader.setRowSetFactory(factory);
 		this.reader.afterPropertiesSet();
 		this.reader.open(executionContext);
 	}
 
 	@Test
-	public void readandMapPlayers() throws Exception {
+	void readAndMapPlayers() throws Exception {
 		Player p1 = this.reader.read();
 		Player p2 = this.reader.read();
 		Player p3 = this.reader.read();
@@ -86,6 +90,7 @@ public class BeanPropertyItemReaderTest {
 		softly.assertThat(1999).isEqualTo(p2.getDebutYear());
 
 		softly.assertAll();
+
 	}
 
 }

--- a/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/mapping/BeanWrapperRowMapperTests.java
+++ b/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/mapping/BeanWrapperRowMapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,10 +37,10 @@ import org.springframework.context.annotation.Scope;
  * @author Marten Deinum
  * @since 0.1.0
  */
-public class BeanWrapperRowMapperTest {
+class BeanWrapperRowMapperTests {
 
 	@Test
-	public void givenNoNameWhenInitCompleteThenIllegalStateShouldOccur() {
+	void givenNoNameWhenInitCompleteThenIllegalStateShouldOccur() {
 		Assertions.assertThatThrownBy(() -> {
 			BeanWrapperRowMapper<Player> mapper = new BeanWrapperRowMapper<>();
 			mapper.afterPropertiesSet();
@@ -48,7 +48,7 @@ public class BeanWrapperRowMapperTest {
 	}
 
 	@Test
-	public void givenAValidRowWhenMappingThenAValidPlayerShouldBeConstructed() throws Exception {
+	void givenAValidRowWhenMappingThenAValidPlayerShouldBeConstructed() throws Exception {
 		BeanWrapperRowMapper<Player> mapper = new BeanWrapperRowMapper<>();
 		mapper.setTargetType(Player.class);
 		mapper.afterPropertiesSet();
@@ -78,7 +78,7 @@ public class BeanWrapperRowMapperTest {
 	}
 
 	@Test
-	public void givenAValidRowWhenMappingThenAValidPlayerShouldBeConstructedBasedOnPrototype() throws Exception {
+	void givenAValidRowWhenMappingThenAValidPlayerShouldBeConstructedBasedOnPrototype() throws Exception {
 
 		ApplicationContext ctx = new AnnotationConfigApplicationContext(TestConfig.class);
 		BeanWrapperRowMapper<Player> mapper = ctx.getBean("playerRowMapper", BeanWrapperRowMapper.class);

--- a/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/poi/PoiItemReaderTypesTests.java
+++ b/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/poi/PoiItemReaderTypesTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.batch.extensions.excel.streaming;
+package org.springframework.batch.extensions.excel.poi;
 
 import java.util.Locale;
 
@@ -26,16 +26,18 @@ import org.springframework.core.io.ClassPathResource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class StreamingXlsxTypesTest {
+
+class PoiItemReaderTypesTests {
 
 	@Test
-	public void shouldBeAbleToReadMultipleTypes() throws Exception {
-		var reader = new StreamingXlsxItemReader<String[]>();
-		reader.setResource(new ClassPathResource("types.xlsx"));
+	void shouldBeAbleToReadMultipleTypes() throws Exception {
+		var reader = new PoiItemReader<String[]>();
+		reader.setResource(new ClassPathResource("types.xls"));
 		reader.setRowMapper(new PassThroughRowMapper());
 		reader.setLinesToSkip(1); // Skip header
 		reader.setUserLocale(Locale.US); // Use a Locale to not be dependent on environment
 		reader.afterPropertiesSet();
+
 
 		reader.open(new ExecutionContext());
 
@@ -47,9 +49,9 @@ public class StreamingXlsxTypesTest {
 	}
 
 	@Test
-	public void shouldBeAbleToReadMultipleTypesWithDatesAsIso() throws Exception {
-		var reader = new StreamingXlsxItemReader<String[]>();
-		reader.setResource(new ClassPathResource("types.xlsx"));
+	void shouldBeAbleToReadMultipleTypesWithDatesAsIso() throws Exception {
+		var reader = new PoiItemReader<String[]>();
+		reader.setResource(new ClassPathResource("types.xls"));
 		reader.setRowMapper(new PassThroughRowMapper());
 		reader.setLinesToSkip(1); // Skip header
 		reader.setUserLocale(Locale.US); // Use a Locale to not be dependent on environment
@@ -64,5 +66,4 @@ public class StreamingXlsxTypesTest {
 		assertThat(row2).containsExactly("2", "2.5", "2023-08-08T00:00:00", "1899-12-31T11:12:13", "2023-08-08T11:12:13", "world hello");
 
 	}
-
 }

--- a/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/poi/PoiItemReaderWithBlankRowSheetTests.java
+++ b/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/poi/PoiItemReaderWithBlankRowSheetTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,14 +35,14 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Marten Deinum
  * @since 0.1.0
  */
-public class PoiItemReaderWithBlankRowSheetTest {
+class PoiItemReaderWithBlankRowSheetTests {
 
 	private final Log logger = LogFactory.getLog(this.getClass());
 
 	private PoiItemReader<String[]> itemReader;
 
 	@BeforeEach
-	public void setup() throws Exception {
+	void setup() {
 		this.itemReader = new PoiItemReader<>();
 		this.itemReader.setResource(new ClassPathResource("blankRow.xlsx"));
 		this.itemReader.setLinesToSkip(1); // First line is column names
@@ -55,7 +55,7 @@ public class PoiItemReaderWithBlankRowSheetTest {
 	}
 
 	@Test
-	public void readExcelFileWithBlankRow() throws Exception {
+	void readExcelFileWithBlankRow() throws Exception {
 		assertThat(this.itemReader.getNumberOfSheets()).isEqualTo(1);
 		String[] row;
 		do {

--- a/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/poi/PoiItemReaderWithErrorsTests.java
+++ b/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/poi/PoiItemReaderWithErrorsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,14 +35,14 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Marten Deinum
  * @since 0.1.0
  */
-public class PoiItemReaderWithErrorsTest {
+class PoiItemReaderWithErrorsTests {
 
 	private final Log logger = LogFactory.getLog(this.getClass());
 
 	private PoiItemReader<String[]> itemReader;
 
 	@BeforeEach
-	public void setup() throws Exception {
+	void setup() {
 		this.itemReader = new PoiItemReader<>();
 		this.itemReader.setResource(new ClassPathResource("errors.xlsx"));
 		this.itemReader.setLinesToSkip(1); // First line is column names
@@ -55,7 +55,7 @@ public class PoiItemReaderWithErrorsTest {
 	}
 
 	@Test
-	public void readExcelFileWithBlankRow() throws Exception {
+	void readExcelFileWithBlankRow() throws Exception {
 		assertThat(this.itemReader.getNumberOfSheets()).isEqualTo(1);
 		String[] row;
 		String[] lastRow = null;

--- a/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/streaming/StreamingXlsxItemReaderTests.java
+++ b/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/streaming/StreamingXlsxItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.springframework.core.io.ClassPathResource;
  * @author Marten Deinum
  * @since 0.1.0
  */
-class StreamingXlsxItemReaderTest extends AbstractExcelItemReaderTests {
+class StreamingXlsxItemReaderTests extends AbstractExcelItemReaderTests {
 
 	@Override
 	protected void configureItemReader(AbstractExcelItemReader<String[]> itemReader) {

--- a/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/streaming/StreamingXlsxItemReaderWithBlankLinesTests.java
+++ b/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/streaming/StreamingXlsxItemReaderWithBlankLinesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.springframework.core.io.ClassPathResource;
  * @author Marten Deinum
  * @since 0.1.0
  */
-class StreamingXlsxItemReaderWithBlankLinesTest extends AbstractExcelItemReaderTests {
+class StreamingXlsxItemReaderWithBlankLinesTests extends AbstractExcelItemReaderTests {
 
 	@Override
 	protected void configureItemReader(AbstractExcelItemReader<String[]> itemReader) {

--- a/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/streaming/StreamingXlsxTypesTests.java
+++ b/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/streaming/StreamingXlsxTypesTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.batch.extensions.excel.poi;
+package org.springframework.batch.extensions.excel.streaming;
 
 import java.util.Locale;
 
@@ -26,18 +26,16 @@ import org.springframework.core.io.ClassPathResource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-
-public class PoiItemReaderTypesTest {
+class StreamingXlsxTypesTests {
 
 	@Test
-	public void shouldBeAbleToReadMultipleTypes() throws Exception {
-		var reader = new PoiItemReader<String[]>();
-		reader.setResource(new ClassPathResource("types.xls"));
+	void shouldBeAbleToReadMultipleTypes() throws Exception {
+		var reader = new StreamingXlsxItemReader<String[]>();
+		reader.setResource(new ClassPathResource("types.xlsx"));
 		reader.setRowMapper(new PassThroughRowMapper());
 		reader.setLinesToSkip(1); // Skip header
 		reader.setUserLocale(Locale.US); // Use a Locale to not be dependent on environment
 		reader.afterPropertiesSet();
-
 
 		reader.open(new ExecutionContext());
 
@@ -49,9 +47,9 @@ public class PoiItemReaderTypesTest {
 	}
 
 	@Test
-	public void shouldBeAbleToReadMultipleTypesWithDatesAsIso() throws Exception {
-		var reader = new PoiItemReader<String[]>();
-		reader.setResource(new ClassPathResource("types.xls"));
+	void shouldBeAbleToReadMultipleTypesWithDatesAsIso() throws Exception {
+		var reader = new StreamingXlsxItemReader<String[]>();
+		reader.setResource(new ClassPathResource("types.xlsx"));
 		reader.setRowMapper(new PassThroughRowMapper());
 		reader.setLinesToSkip(1); // Skip header
 		reader.setUserLocale(Locale.US); // Use a Locale to not be dependent on environment
@@ -66,4 +64,5 @@ public class PoiItemReaderTypesTest {
 		assertThat(row2).containsExactly("2", "2.5", "2023-08-08T00:00:00", "1899-12-31T11:12:13", "2023-08-08T11:12:13", "world hello");
 
 	}
+
 }

--- a/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/support/rowset/DefaultRowSetMetaDataTests.java
+++ b/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/support/rowset/DefaultRowSetMetaDataTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
  * @author Marten Deinum
  * @since 0.1.0
  */
-public class DefaultRowSetMetaDataTest {
+class DefaultRowSetMetaDataTests {
 
 	private static final String[] COLUMNS = { "col1", "col2", "col3" };
 
@@ -45,14 +45,14 @@ public class DefaultRowSetMetaDataTest {
 	private ColumnNameExtractor columnNameExtractor;
 
 	@BeforeEach
-	public void setup() {
+	void setup() {
 		this.sheet = Mockito.mock(Sheet.class);
 		this.columnNameExtractor = Mockito.mock(ColumnNameExtractor.class);
 		this.rowSetMetaData = new DefaultRowSetMetaData(this.sheet, this.columnNameExtractor);
 	}
 
 	@Test
-	public void shouldReturnColumnsFromColumnNameExtractor() {
+	void shouldReturnColumnsFromColumnNameExtractor() {
 
 		given(this.columnNameExtractor.getColumnNames(this.sheet)).willReturn(COLUMNS);
 
@@ -65,7 +65,7 @@ public class DefaultRowSetMetaDataTest {
 	}
 
 	@Test
-	public void shouldGetAndReturnNameOfTheSheet() {
+	void shouldGetAndReturnNameOfTheSheet() {
 
 		given(this.sheet.getName()).willReturn("testing123");
 

--- a/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/support/rowset/StaticColumnNameExtractorTests.java
+++ b/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/support/rowset/StaticColumnNameExtractorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,12 +24,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Marten Deinum
  * @since 0.1.0
  */
-public class StaticColumnNameExtractorTest {
+class StaticColumnNameExtractorTests {
 
 	private static final String[] COLUMNS = { "col1", "col2", "col3", "foo", "bar" };
 
 	@Test
-	public void shouldReturnSameHeadersAsPassedIn() {
+	void shouldReturnSameHeadersAsPassedIn() {
 
 		StaticColumnNameExtractor columnNameExtractor = new StaticColumnNameExtractor(COLUMNS);
 		String[] names = columnNameExtractor.getColumnNames(null);
@@ -39,7 +39,7 @@ public class StaticColumnNameExtractorTest {
 	}
 
 	@Test
-	public void shouldReturnACopyOfTheHeaders() {
+	void shouldReturnACopyOfTheHeaders() {
 
 		StaticColumnNameExtractor columnNameExtractor = new StaticColumnNameExtractor(COLUMNS);
 		String[] names = columnNameExtractor.getColumnNames(null);


### PR DESCRIPTION
With this commit we upgrade the java formatting to the new version and also adhere to the standards applied there. Mainly for Junit5 names of the test classes and visibility of methods.

Closes: #138