### PR TITLE
Improve IsoFormattingDateDataFormatter

### DIFF
--- a/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/poi/PoiItemReaderXlsTypesTests.java
+++ b/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/poi/PoiItemReaderXlsTypesTests.java
@@ -27,7 +27,7 @@ import org.springframework.core.io.ClassPathResource;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-class PoiItemReaderTypesTests {
+class PoiItemReaderXlsTypesTests {
 
 	@Test
 	void shouldBeAbleToReadMultipleTypes() throws Exception {
@@ -37,7 +37,6 @@ class PoiItemReaderTypesTests {
 		reader.setLinesToSkip(1); // Skip header
 		reader.setUserLocale(Locale.US); // Use a Locale to not be dependent on environment
 		reader.afterPropertiesSet();
-
 
 		reader.open(new ExecutionContext());
 
@@ -62,8 +61,7 @@ class PoiItemReaderTypesTests {
 
 		var row1 = reader.read();
 		var row2 = reader.read();
-		assertThat(row1).containsExactly("1", "1.0", "2024-05-12T00:00:00", "1899-12-31T13:14:55", "2024-05-12T13:14:55", "hello world");
-		assertThat(row2).containsExactly("2", "2.5", "2023-08-08T00:00:00", "1899-12-31T11:12:13", "2023-08-08T11:12:13", "world hello");
-
+		assertThat(row1).containsExactly("1", "1.0", "2024-05-12", "13:14:55", "2024-05-12T13:14:55", "hello world");
+		assertThat(row2).containsExactly("2", "2.5", "2023-08-08", "11:12:13", "2023-08-08T11:12:13", "world hello");
 	}
 }

--- a/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/poi/PoiItemReaderXlsxTypesTests.java
+++ b/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/poi/PoiItemReaderXlsxTypesTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.batch.extensions.excel.streaming;
+package org.springframework.batch.extensions.excel.poi;
 
 import java.util.Locale;
 
@@ -26,11 +26,11 @@ import org.springframework.core.io.ClassPathResource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class StreamingXlsxTypesTests {
+class PoiItemReaderXlsxTypesTests {
 
 	@Test
 	void shouldBeAbleToReadMultipleTypes() throws Exception {
-		var reader = new StreamingXlsxItemReader<String[]>();
+		var reader = new PoiItemReader<String[]>();
 		reader.setResource(new ClassPathResource("types.xlsx"));
 		reader.setRowMapper(new PassThroughRowMapper());
 		reader.setLinesToSkip(1); // Skip header
@@ -47,8 +47,8 @@ class StreamingXlsxTypesTests {
 
 	@Test
 	void shouldBeAbleToReadMultipleTypesWithDatesAsIso() throws Exception {
-		var reader = new StreamingXlsxItemReader<String[]>();
-		reader.setResource(new ClassPathResource("types.xlsx"));
+		var reader = new PoiItemReader<String[]>();
+		reader.setResource(new ClassPathResource("types.xls"));
 		reader.setRowMapper(new PassThroughRowMapper());
 		reader.setLinesToSkip(1); // Skip header
 		reader.setUserLocale(Locale.US); // Use a Locale to not be dependent on environment


### PR DESCRIPTION
Prior to this commit all date related fields were formatted as an ISO_LOCAL_DATE_TIME.

With this commit we inspect the type it actually is date, time or datetime and use the proper ISO_LOCAL formatting for that.

Another improvement is to use the cached result for the formula instead of re-evaluating the formula and use that type.