### PR TITLE
Bump spring-batch-neo4j to 1.0.0-SNAPSHOT

### DIFF
--- a/spring-batch-neo4j/pom.xml
+++ b/spring-batch-neo4j/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>org.springframework.batch.extensions</groupId>
     <artifactId>spring-batch-neo4j</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <name>Spring Batch Neo4j</name>
     <description>Spring Batch extension for Neo4j</description>
     <url>https://github.com/spring-projects/spring-batch-extensions/tree/main/spring-batch-neo4j</url>


### PR DESCRIPTION
#125 upgraded the dependencies to the latest versions, which implicitly increased the required Java version from 8 to 17.

For this reason, I am increasing the major version to signal the breaking change better. 