### PR TITLE
Add streaming ItemReader for legacy .xls files

### DIFF
--- a/spring-batch-excel/README.adoc
+++ b/spring-batch-excel/README.adoc
@@ -1,10 +1,10 @@
 = spring-batch-excel
 
-Spring Batch extension containing an `ItemReader` implementation for Excel based on https://poi.apache.org[Apache POI]. It supports reading both XLS and XLSX files. For the latter, there is also (experimental) streaming support.
+Spring Batch extension containing an `ItemReader` implementation for Excel based on https://poi.apache.org[Apache POI]. It supports reading both XLS and XLSX files. For both formats there is also (experimental) streaming support.
 
 The `PoiItemReader` has the most features but is also the most memory intensive and might lead to memory issues with large XLS(X) sheets.
 
-To reduce the memory footprint the `StreamingXlsxItemReader` can be used, this will only keep the current row in memory and discard it afterward. Not everything is supported while streaming the XLSX file. It can be that formulas don't get evaluated or lead to an error.
+To reduce the memory footprint the `StreamingXlsxItemReader` (for XLSX) or the `StreamingXlsItemReader` (for legacy binary XLS) can be used, these will only keep the current row in memory and discard it afterward. Not everything is supported while streaming. It can be that formulas don't get evaluated or lead to an error.
 
 WARNING: The `ItemReader` classess are **not threadsafe**. The API from https://poi.apache.org/help/faq.html#20[Apache POI] itself isn't threadsafe as well as the https://docs.spring.io/spring-batch/docs/current/api/org/springframework/batch/item/support/AbstractItemCountingItemStreamItemReader.html[`AbstractItemCountingItemStreamItemReader`] used as a base class for the `ItemReader` classes. Reading from multiple threads is therefore not supported. Using a multi-threaded processor/writer should work as long as you use a single thread for reading.
 
@@ -82,6 +82,43 @@ public RowMapper rowMapper() {
 }
 ----
 
+== Configuration of `StreamingXlsItemReader`
+
+The `StreamingXlsItemReader` is the low-memory streaming reader for legacy binary `.xls` (BIFF8/HSSF) files, the counterpart of the `StreamingXlsxItemReader`. Like that reader it only keeps the current row in memory. While streaming, formulas are not evaluated (the cached value stored in the file is returned) and password protected files are not supported.
+
+Configuration can be done in XML or Java Config.
+
+=== XML
+
+[source,xml]
+----
+ <bean id="excelReader" class="org.springframework.batch.extensions.excel.streaming.StreamingXlsItemReader" scope="step">
+     <property name="resource" value="file:/path/to/your/excel/file" />
+     <property name="rowMapper">
+         <bean class="org.springframework.batch.extensions.excel.mapping.PassThroughRowMapper" />
+     </property>
+ </bean>
+----
+
+=== Java Config
+
+[source,java]
+----
+@Bean
+@StepScope
+public StreamingXlsItemReader excelReader(RowMapper rowMapper) {
+    StreamingXlsItemReader reader = new StreamingXlsItemReader();
+    reader.setResource(new FileSystemResource("/path/to/your/excel/file"));
+    reader.setRowMapper(rowMapper);
+    return reader;
+}
+
+@Bean
+public RowMapper rowMapper() {
+    return new PassThroughRowMapper();
+}
+----
+
 == Configuration properties
 [cols="1,1,1,4"]
 .Properties for item readers
@@ -148,7 +185,7 @@ public BeanWrapperRowMapper rowMapper() {
 }
 ----
 
-NOTE: When using the `BeanWrapperRowMapper` with the `StreamingXlsxItemReader` it is required to use the `StaticColumnNameExtractor` to provide the column names for mapping purposes. The reason for this is that we cannot read a specific row while streaming the results.
+NOTE: When using the `BeanWrapperRowMapper` with one of the streaming item readers (`StreamingXlsxItemReader` or `StreamingXlsItemReader`) it is required to use the `StaticColumnNameExtractor` to provide the column names for mapping purposes. The reason for this is that we cannot read a specific row while streaming the results.
 
 [source,xml]
 ----

--- a/spring-batch-excel/src/main/java/org/springframework/batch/extensions/excel/streaming/StreamingXlsItemReader.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/extensions/excel/streaming/StreamingXlsItemReader.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2006-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.batch.extensions.excel.streaming;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.poi.hssf.record.BoundSheetRecord;
+import org.apache.poi.hssf.record.EOFRecord;
+import org.apache.poi.hssf.record.ExtendedFormatRecord;
+import org.apache.poi.hssf.record.FormatRecord;
+import org.apache.poi.hssf.record.Record;
+import org.apache.poi.hssf.record.RecordFactoryInputStream;
+import org.apache.poi.hssf.record.SSTRecord;
+import org.apache.poi.poifs.filesystem.DocumentInputStream;
+import org.apache.poi.poifs.filesystem.POIFSFileSystem;
+
+import org.springframework.batch.extensions.excel.AbstractExcelItemReader;
+import org.springframework.batch.extensions.excel.Sheet;
+import org.springframework.core.io.Resource;
+
+/**
+ * Low-memory streaming {@code ItemReader} for legacy binary {@code .xls} (BIFF8 / HSSF)
+ * workbooks. It mirrors {@link StreamingXlsxItemReader} but reads the OLE2
+ * {@code "Workbook"} stream record-by-record using Apache POI's pull primitive
+ * {@link RecordFactoryInputStream}, so rows are produced lazily with a bounded memory
+ * footprint instead of materialising the whole workbook object graph like the
+ * {@code PoiItemReader}.
+ * <p>
+ * The shared, immutable workbook globals (the {@link SSTRecord shared-string table} and
+ * the number/date format table) are read once when the file is opened and handed,
+ * read-only, to every {@link XlsSheet}. Each sheet then opens its own stream positioned
+ * at its {@code BOF} offset, matching the way {@code StreamingXlsxItemReader} gives every
+ * sheet its own {@code InputStream}.
+ * <p>
+ * Encrypted {@code .xls} files are not supported by this reader (consistent with
+ * {@code StreamingXlsxItemReader}); a configured password is ignored.
+ *
+ * @param <T> the type
+ * @author Kebba Manneh
+ * @since 0.3.0
+ */
+public class StreamingXlsItemReader<T> extends AbstractExcelItemReader<T> {
+
+	/**
+	 * Candidate names of the workbook stream inside the OLE2 container, newest first.
+	 */
+	private static final String[] WORKBOOK_ENTRY_NAMES = {"Workbook", "Book", "WORKBOOK", "BOOK", "workbook", "book"};
+
+	private final List<XlsSheet> sheets = new ArrayList<>();
+
+	private POIFSFileSystem poifs;
+
+	@Override
+	protected Sheet getSheet(int sheet) {
+		return this.sheets.get(sheet);
+	}
+
+	@Override
+	protected int getNumberOfSheets() {
+		return this.sheets.size();
+	}
+
+	@Override
+	protected void openExcelFile(Resource resource, String password) throws Exception {
+		this.poifs = resource.isFile() ? new POIFSFileSystem(resource.getFile())
+				: new POIFSFileSystem(resource.getInputStream());
+		String workbookEntry = resolveWorkbookEntry(this.poifs);
+		initSheets(workbookEntry);
+	}
+
+	// Read the globals substream once to capture the shared, immutable state (shared
+	// strings + format table + the bound sheets), then create one lazy XlsSheet per
+	// worksheet sharing that state.
+	private void initSheets(String workbookEntry) throws IOException {
+		SSTRecord sst = null;
+		List<ExtendedFormatRecord> extendedFormats = new ArrayList<>();
+		Map<Integer, String> formats = new HashMap<>();
+		List<BoundSheetRecord> boundSheets = new ArrayList<>();
+
+		try (DocumentInputStream dis = this.poifs.createDocumentInputStream(workbookEntry)) {
+			RecordFactoryInputStream rfis = new RecordFactoryInputStream(dis, false);
+			Record record;
+			while ((record = rfis.nextRecord()) != null) {
+				if (record instanceof EOFRecord) {
+					// End of the globals substream, everything shared has been read.
+					break;
+				}
+				else if (record instanceof SSTRecord sstRecord) {
+					sst = sstRecord;
+				}
+				else if (record instanceof ExtendedFormatRecord extendedFormat) {
+					extendedFormats.add(extendedFormat);
+				}
+				else if (record instanceof FormatRecord format) {
+					formats.put(format.getIndexCode(), format.getFormatString());
+				}
+				else if (record instanceof BoundSheetRecord boundSheet) {
+					boundSheets.add(boundSheet);
+				}
+			}
+		}
+
+		for (BoundSheetRecord boundSheet : BoundSheetRecord.orderByBofPosition(boundSheets)) {
+			this.sheets.add(new XlsSheet(boundSheet.getSheetname(), this.poifs, workbookEntry,
+					boundSheet.getPositionOfBof(), sst, extendedFormats, formats, getDataFormatter()));
+		}
+
+		if (this.logger.isTraceEnabled()) {
+			this.logger.trace("Prepared " + this.sheets.size() + " sheets.");
+		}
+	}
+
+	private static String resolveWorkbookEntry(POIFSFileSystem poifs) {
+		for (String name : WORKBOOK_ENTRY_NAMES) {
+			if (poifs.getRoot().hasEntry(name)) {
+				return name;
+			}
+		}
+		throw new IllegalStateException("Unable to locate a workbook stream in the OLE2 container.");
+	}
+
+	@Override
+	protected void doClose() throws Exception {
+		for (XlsSheet sheet : this.sheets) {
+			sheet.close();
+		}
+		this.sheets.clear();
+
+		if (this.poifs != null) {
+			this.poifs.close();
+			this.poifs = null;
+		}
+		super.doClose();
+	}
+
+}

--- a/spring-batch-excel/src/main/java/org/springframework/batch/extensions/excel/streaming/XlsSheet.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/extensions/excel/streaming/XlsSheet.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright 2006-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.batch.extensions.excel.streaming;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.poi.hssf.record.BlankRecord;
+import org.apache.poi.hssf.record.BoolErrRecord;
+import org.apache.poi.hssf.record.CellValueRecordInterface;
+import org.apache.poi.hssf.record.DimensionsRecord;
+import org.apache.poi.hssf.record.EOFRecord;
+import org.apache.poi.hssf.record.ExtendedFormatRecord;
+import org.apache.poi.hssf.record.FormulaRecord;
+import org.apache.poi.hssf.record.LabelRecord;
+import org.apache.poi.hssf.record.LabelSSTRecord;
+import org.apache.poi.hssf.record.MulBlankRecord;
+import org.apache.poi.hssf.record.MulRKRecord;
+import org.apache.poi.hssf.record.NumberRecord;
+import org.apache.poi.hssf.record.RKRecord;
+import org.apache.poi.hssf.record.Record;
+import org.apache.poi.hssf.record.RecordFactoryInputStream;
+import org.apache.poi.hssf.record.SSTRecord;
+import org.apache.poi.hssf.record.StringRecord;
+import org.apache.poi.poifs.filesystem.DocumentInputStream;
+import org.apache.poi.poifs.filesystem.POIFSFileSystem;
+import org.apache.poi.ss.usermodel.BuiltinFormats;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.DataFormatter;
+import org.apache.poi.ss.usermodel.FormulaError;
+
+import org.springframework.batch.extensions.excel.Sheet;
+import org.springframework.util.StringUtils;
+
+/**
+ * {@code Sheet} implementation for a single worksheet of a legacy binary {@code .xls}
+ * (HSSF) workbook, reading the rows lazily from POI's
+ * {@link RecordFactoryInputStream} pull stream. It is the HSSF analogue of
+ * {@link StreamingSheet}.
+ *
+ * @author Kebba Manneh
+ * @since 0.3.0
+ */
+class XlsSheet implements Sheet {
+
+	private final Log logger = LogFactory.getLog(XlsSheet.class);
+
+	private final String name;
+
+	private final POIFSFileSystem poifs;
+
+	private final String workbookEntry;
+
+	private final int positionOfBof;
+
+	private final SSTRecord sst;
+
+	private final List<ExtendedFormatRecord> extendedFormats;
+
+	private final Map<Integer, String> formats;
+
+	private final DataFormatter dataFormatter;
+
+	private DocumentInputStream documentStream;
+
+	private RecordFactoryInputStream records;
+
+	private boolean opened;
+
+	private boolean exhausted;
+
+	private int rowCount;
+
+	private int colCount;
+
+	private String[] staged;
+
+	private int currentRow = -1;
+
+	private int pendingFormulaColumn = -1;
+
+	private Record bufferedCell;
+
+	XlsSheet(String name, POIFSFileSystem poifs, String workbookEntry, int positionOfBof, SSTRecord sst,
+			List<ExtendedFormatRecord> extendedFormats, Map<Integer, String> formats, DataFormatter dataFormatter) {
+		this.name = name;
+		this.poifs = poifs;
+		this.workbookEntry = workbookEntry;
+		this.positionOfBof = positionOfBof;
+		this.sst = sst;
+		this.extendedFormats = extendedFormats;
+		this.formats = formats;
+		this.dataFormatter = dataFormatter;
+	}
+
+	@Override
+	public int getNumberOfRows() {
+		return this.rowCount;
+	}
+
+	@Override
+	public String getName() {
+		return this.name;
+	}
+
+	@Override
+	public String[] getRow(int rowNumber) {
+		throw new UnsupportedOperationException("Getting row by index not supported when streaming.");
+	}
+
+	/**
+	 * Lazily open an own stream over the workbook, positioned at this sheet's {@code BOF}
+	 * record, mirroring the way each {@link StreamingSheet} reads its own
+	 * {@code InputStream}.
+	 */
+	private void ensureOpen() throws IOException {
+		if (this.opened) {
+			return;
+		}
+		this.documentStream = this.poifs.createDocumentInputStream(this.workbookEntry);
+		skipFully(this.documentStream, this.positionOfBof);
+		this.records = new RecordFactoryInputStream(this.documentStream, false);
+		this.opened = true;
+	}
+
+	private String[] nextRow() {
+		try {
+			ensureOpen();
+			if (this.exhausted && this.bufferedCell == null) {
+				return null;
+			}
+
+			// Seed the new row from the one-cell look-ahead captured at the previous
+			// row boundary, if any.
+			if (this.bufferedCell != null) {
+				Record cell = this.bufferedCell;
+				this.bufferedCell = null;
+				startRow(rowOf(cell));
+				place(cell);
+			}
+
+			Record record;
+			while ((record = this.records.nextRecord()) != null) {
+				if (record instanceof EOFRecord) {
+					this.exhausted = true;
+					return flush();
+				}
+				else if (record instanceof DimensionsRecord dimensions) {
+					this.colCount = dimensions.getLastCol();
+					this.rowCount = dimensions.getLastRow();
+				}
+				else if (record instanceof StringRecord stringRecord) {
+					// The cached string result of the preceding formula record.
+					if (this.pendingFormulaColumn >= 0 && this.staged != null) {
+						this.staged[this.pendingFormulaColumn] = stringRecord.getString();
+					}
+					this.pendingFormulaColumn = -1;
+				}
+				else {
+					int row = rowOf(record);
+					if (row < 0) {
+						continue;
+					}
+					if (this.staged != null && row != this.currentRow) {
+						// A new row started: hold this cell back and flush the previous row.
+						this.bufferedCell = record;
+						return flush();
+					}
+					if (this.staged == null) {
+						startRow(row);
+					}
+					place(record);
+				}
+			}
+			this.exhausted = true;
+			return flush();
+		}
+		catch (IOException ex) {
+			throw new IllegalStateException("Error reading file.", ex);
+		}
+	}
+
+	private void startRow(int row) {
+		this.currentRow = row;
+		this.pendingFormulaColumn = -1;
+		this.staged = new String[Math.max(this.colCount, 0)];
+		Arrays.fill(this.staged, "");
+	}
+
+	private String[] flush() {
+		if (this.staged == null) {
+			return null;
+		}
+		String[] result = Arrays.copyOf(this.staged, this.staged.length);
+		this.staged = null;
+		this.currentRow = -1;
+		if (this.logger.isTraceEnabled()) {
+			this.logger.trace("Row ended, returning: " + StringUtils.arrayToCommaDelimitedString(result));
+		}
+		return result;
+	}
+
+	private static int rowOf(Record record) {
+		if (record instanceof CellValueRecordInterface cell) {
+			return cell.getRow();
+		}
+		if (record instanceof MulRKRecord mulRk) {
+			return mulRk.getRow();
+		}
+		if (record instanceof MulBlankRecord mulBlank) {
+			return mulBlank.getRow();
+		}
+		return -1;
+	}
+
+	private void place(Record record) {
+		if (record instanceof MulRKRecord mulRk) {
+			ensureCapacity(mulRk.getLastColumn());
+			for (int i = 0; i < mulRk.getNumColumns(); i++) {
+				this.staged[mulRk.getFirstColumn() + i] = format(mulRk.getRKNumberAt(i), mulRk.getXFAt(i));
+			}
+			return;
+		}
+		if (record instanceof MulBlankRecord mulBlank) {
+			ensureCapacity(mulBlank.getLastColumn());
+			for (int col = mulBlank.getFirstColumn(); col <= mulBlank.getLastColumn(); col++) {
+				this.staged[col] = "";
+			}
+			return;
+		}
+		CellValueRecordInterface cell = (CellValueRecordInterface) record;
+		int col = cell.getColumn();
+		ensureCapacity(col);
+		this.staged[col] = value(cell);
+	}
+
+	private String value(CellValueRecordInterface cell) {
+		if (cell instanceof LabelSSTRecord label) {
+			return this.sst.getString(label.getSSTIndex()).getString();
+		}
+		if (cell instanceof NumberRecord number) {
+			return format(number.getValue(), number.getXFIndex());
+		}
+		if (cell instanceof RKRecord rk) {
+			return format(rk.getRKNumber(), rk.getXFIndex());
+		}
+		if (cell instanceof BlankRecord) {
+			return "";
+		}
+		if (cell instanceof BoolErrRecord boolErr) {
+			if (boolErr.isBoolean()) {
+				return boolErr.getBooleanValue() ? "TRUE" : "FALSE";
+			}
+			return FormulaError.forInt(boolErr.getErrorValue()).getString();
+		}
+		if (cell instanceof LabelRecord label) {
+			return label.getValue();
+		}
+		if (cell instanceof FormulaRecord formula) {
+			return formulaValue(cell.getColumn(), formula);
+		}
+		return "";
+	}
+
+	private String formulaValue(int column, FormulaRecord formula) {
+		if (formula.hasCachedResultString()) {
+			// The string result is supplied by the StringRecord that follows; mark the
+			// column so it can be filled in when that record arrives.
+			this.pendingFormulaColumn = column;
+			return "";
+		}
+		CellType type = formula.getCachedResultTypeEnum();
+		if (type == CellType.BOOLEAN) {
+			return formula.getCachedBooleanValue() ? "TRUE" : "FALSE";
+		}
+		if (type == CellType.ERROR) {
+			return FormulaError.forInt(formula.getCachedErrorValue()).getString();
+		}
+		return format(formula.getValue(), formula.getXFIndex());
+	}
+
+	// Format a numeric (or date) value using the cell's extended format, reproducing what
+	// FormatTrackingHSSFListener does in event mode.
+	private String format(double value, int xfIndex) {
+		int formatIndex = 0;
+		String formatString = null;
+		if (xfIndex >= 0 && xfIndex < this.extendedFormats.size()) {
+			formatIndex = this.extendedFormats.get(xfIndex).getFormatIndex() & 0xFFFF;
+			formatString = this.formats.get(formatIndex);
+			if (formatString == null) {
+				formatString = BuiltinFormats.getBuiltinFormat(formatIndex);
+			}
+		}
+		if (formatString == null) {
+			formatString = BuiltinFormats.getBuiltinFormat(0);
+		}
+		return this.dataFormatter.formatRawCellContents(value, formatIndex, formatString);
+	}
+
+	private void ensureCapacity(int column) {
+		if (this.staged == null) {
+			this.staged = new String[column + 1];
+			Arrays.fill(this.staged, "");
+		}
+		else if (this.staged.length <= column) {
+			int previous = this.staged.length;
+			this.staged = Arrays.copyOf(this.staged, column + 1);
+			for (int i = previous; i < this.staged.length; i++) {
+				this.staged[i] = "";
+			}
+		}
+	}
+
+	private static void skipFully(DocumentInputStream stream, long bytes) throws IOException {
+		long remaining = bytes;
+		while (remaining > 0) {
+			long skipped = stream.skip(remaining);
+			if (skipped <= 0) {
+				if (stream.read() < 0) {
+					throw new IOException("Reached end of stream before the sheet offset.");
+				}
+				skipped = 1;
+			}
+			remaining -= skipped;
+		}
+	}
+
+	@Override
+	public void close() throws Exception {
+		if (this.documentStream != null) {
+			this.documentStream.close();
+			this.documentStream = null;
+		}
+	}
+
+	@Override
+	public Iterator<String[]> iterator() {
+		return new Iterator<>() {
+
+			private String[] currentRow;
+
+			@Override
+			public boolean hasNext() {
+				this.currentRow = nextRow();
+				return this.currentRow != null;
+			}
+
+			@Override
+			public String[] next() {
+				return this.currentRow;
+			}
+		};
+	}
+
+}

--- a/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/streaming/StreamingXlsItemReaderTests.java
+++ b/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/streaming/StreamingXlsItemReaderTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2002-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.batch.extensions.excel.streaming;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.provider.Arguments;
+
+import org.springframework.batch.extensions.excel.AbstractExcelItemReader;
+import org.springframework.batch.extensions.excel.AbstractExcelItemReaderTests;
+
+/**
+ * @author Kebba Manneh
+ * @since 0.3.0
+ */
+class StreamingXlsItemReaderTests extends AbstractExcelItemReaderTests {
+
+	@Override
+	protected AbstractExcelItemReader<String[]> createExcelItemReader() {
+		return new StreamingXlsItemReader<>();
+	}
+
+	@Override
+	protected Stream<Arguments> scenarios() {
+		return Stream.of(
+				Arguments.of("classpath:/player.xls", NOOP),
+				Arguments.of("classpath:/player_with_blank_lines.xls", NOOP));
+	}
+}

--- a/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/streaming/StreamingXlsMappingTests.java
+++ b/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/streaming/StreamingXlsMappingTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2002-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.batch.extensions.excel.streaming;
+
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.batch.extensions.excel.Player;
+import org.springframework.batch.extensions.excel.ReflectionTestUtils;
+import org.springframework.batch.extensions.excel.mapping.BeanWrapperRowMapper;
+import org.springframework.batch.extensions.excel.support.rowset.DefaultRowSetFactory;
+import org.springframework.batch.extensions.excel.support.rowset.StaticColumnNameExtractor;
+import org.springframework.batch.infrastructure.item.ExecutionContext;
+import org.springframework.core.io.ClassPathResource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StreamingXlsMappingTests {
+
+	@Test
+	void readAndMapRowsUsingRowMapper() throws Exception {
+		var columns = new String[] {"id", "position", "lastName", "firstName", "birthYear", "debutYear"};
+		var rowSetFactory = new DefaultRowSetFactory();
+		rowSetFactory.setColumnNameExtractor(new StaticColumnNameExtractor(columns));
+
+		var mapper = new BeanWrapperRowMapper<Player>();
+		mapper.setTargetType(Player.class);
+
+		var reader = new StreamingXlsItemReader<Player>();
+		reader.setResource(new ClassPathResource("player.xls"));
+		reader.setRowSetFactory(rowSetFactory);
+		reader.setRowMapper(mapper);
+		reader.setLinesToSkip(1); // Skip header
+		reader.setUserLocale(Locale.US); // Use a Locale to not be dependent on environment
+		reader.afterPropertiesSet();
+
+		reader.open(new ExecutionContext());
+		Player row;
+		do {
+			row = reader.read();
+		}
+		while (row != null);
+
+		Integer readCount = (Integer) ReflectionTestUtils.getField(reader, "currentItemCount");
+		assertThat(readCount).isEqualTo(4321);
+	}
+}

--- a/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/streaming/StreamingXlsTypesTests.java
+++ b/spring-batch-excel/src/test/java/org/springframework/batch/extensions/excel/streaming/StreamingXlsTypesTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2002-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.batch.extensions.excel.streaming;
+
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.batch.extensions.excel.mapping.PassThroughRowMapper;
+import org.springframework.batch.infrastructure.item.ExecutionContext;
+import org.springframework.core.io.ClassPathResource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StreamingXlsTypesTests {
+
+	@Test
+	void shouldBeAbleToReadMultipleTypes() throws Exception {
+		var reader = new StreamingXlsItemReader<String[]>();
+		reader.setResource(new ClassPathResource("types.xls"));
+		reader.setRowMapper(new PassThroughRowMapper());
+		reader.setLinesToSkip(1); // Skip header
+		reader.setUserLocale(Locale.US); // Use a Locale to not be dependent on environment
+		reader.afterPropertiesSet();
+
+		reader.open(new ExecutionContext());
+
+		var row1 = reader.read();
+		var row2 = reader.read();
+		assertThat(row1).containsExactly("1", "1.0", "5/12/24", "13:14:55", "5/12/24 13:14", "hello world");
+		assertThat(row2).containsExactly("2", "2.5", "8/8/23", "11:12:13", "8/8/23 11:12", "world hello");
+	}
+
+	@Test
+	void shouldBeAbleToReadMultipleTypesWithDatesAsIso() throws Exception {
+		var reader = new StreamingXlsItemReader<String[]>();
+		reader.setResource(new ClassPathResource("types.xls"));
+		reader.setRowMapper(new PassThroughRowMapper());
+		reader.setLinesToSkip(1); // Skip header
+		reader.setUserLocale(Locale.US); // Use a Locale to not be dependent on environment
+		reader.setDatesAsIso(true);
+		reader.afterPropertiesSet();
+
+		reader.open(new ExecutionContext());
+
+		var row1 = reader.read();
+		var row2 = reader.read();
+		assertThat(row1).containsExactly("1", "1.0", "2024-05-12", "13:14:55", "2024-05-12T13:14:55", "hello world");
+		assertThat(row2).containsExactly("2", "2.5", "2023-08-08", "11:12:13", "2023-08-08T11:12:13", "world hello");
+	}
+}


### PR DESCRIPTION
Fixes #215

Adds a low-memory streaming reader for legacy binary `.xls` (BIFF8/HSSF) files - the
HSSF counterpart to the existing `StreamingXlsxItemReader`.

### What this adds
- `StreamingXlsItemReader<T>` and a package-private `XlsSheet` in the `streaming`
  package, both built on the existing `Sheet` (`Iterable<String[]>`) abstraction and
  `AbstractExcelItemReader`, so all current configuration, mapping, blank-row handling
  and restart behaviour are inherited unchanged.

### Approach
- Reads HSSF records in *pull* mode via `RecordFactoryInputStream#nextRecord()` - the
  HSSF analogue of the StAX loop in `StreamingSheet` - assembling rows one at a time,
  so memory stays bounded regardless of file size.
- The shared strings table is read once from the workbook globals and shared across
  sheets; each sheet is exposed as its own stream positioned at its `BoundSheetRecord`
  offset, mirroring how the xlsx reader gives each sheet an independent stream.
- Formulas return the cached value, consistent with the streaming xlsx reader.

### Notes
- Additive only: no changes to existing readers, abstractions, or dependencies.
- `./mvnw -B package` is green (compile + `io.spring.javaformat` checkstyle + tests).
- Commits are DCO signed-off.