### PR TITLE
Remove duplicated "the"

### DIFF
--- a/spring-batch-excel/src/main/java/org/springframework/batch/extensions/excel/support/rowset/RowSetMetaData.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/extensions/excel/support/rowset/RowSetMetaData.java
@@ -17,7 +17,7 @@
 package org.springframework.batch.extensions.excel.support.rowset;
 
 /**
- * Interface representing the the metadata associated with an Excel document.
+ * Interface representing the metadata associated with an Excel document.
  *
  * @author Marten Deinum
  * @since 0.1.0


### PR DESCRIPTION
This PR fixes a typo of "the the" to "the".